### PR TITLE
Update method to define `initialHasLiked` to perform a successful `unlike` action from the `like` button on CocktailCard

### DIFF
--- a/src/features/cocktails/CocktailCard.jsx
+++ b/src/features/cocktails/CocktailCard.jsx
@@ -39,7 +39,7 @@ const CocktailCard = ({ id }) => {
 	const [deleteLike] = useDeleteLikeMutation()
 
 	const initialHasLiked = useMemo(
-		() => currentUser.likes.some((like) => like.liked_cocktail_id === id),
+		() => currentUser.likes.find((like) => like.liked_cocktail_id === id),
 		[currentUser.likes, id]
 	)
 


### PR DESCRIPTION
To determine if the current user has already liked a cocktail, a method of `some` was initially used. However, `some` returns a boolean, while we need the `like` object with the associated `id` in order to perform the `unlike` action. 
`find` method is used to replace `some` to return the `like` object we need