### PR TITLE
Remove authentication for non-profile pages, add log in/sign up prompts

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -35,12 +35,12 @@ function App() {
 					<Route path="/login" element={<Login />} />
 					<Route element={<ProtectedRoute />}>
 						<Route path="/profile" element={<Profile />} />
-						<Route path="/cocktails" element={<CocktailsContainer />} />
-						<Route path="/cocktails/:id" element={<CocktailDetail />} />
 						<Route path="/cocktails/:id/edit" element={<CocktailEdit />} />
 					</Route>
 					<Route path="/categories" element={<CategoriesContainer />} />
 					<Route path="/categories/:id" element={<CategoryDetail />} />
+					<Route path="/cocktails" element={<CocktailsContainer />} />
+					<Route path="/cocktails/:id" element={<CocktailDetail />} />
 					<Route path="*" element={<Navigate to="/" replace />} />
 				</Routes>
 			</Suspense>

--- a/src/components/App/App.module.css
+++ b/src/components/App/App.module.css
@@ -79,7 +79,6 @@
   box-shadow: 10px 10px 10px 1px rgba(0, 0, 0, 0.2);
   opacity: 85%;
   padding: 2rem 5rem 2rem;
-
 }
 .form__button {
   align-items: center;
@@ -93,7 +92,6 @@
   justify-content: center;
   margin: 0.5rem 0 0;
   opacity: 0.7;
-  outline: none;
   padding: 8px;
   transition: 1s;
 }
@@ -126,7 +124,6 @@
   justify-content: center;
   letter-spacing: 1px;
   margin-top: 0.25rem;
-  outline: none;
   padding: 8px;
   transition: 1s;
   width: 100%;
@@ -149,14 +146,12 @@
   font-weight: 600;
   justify-content: center;
   letter-spacing: 1px;
-  outline: none;
   padding: 8px;
   transition: 1s;
   width: 100%;
 }
 .form__select:focus {
   border-color: #706897;
-  outline: none;
 }
 /* Remove the blue outline on select elements in Firefox */
 .form__select:-moz-focusring {
@@ -311,7 +306,6 @@ background:#a6efed;
 }
 
 .like:focus {
-  outline: none;
 }
 
 .image-cocktail{
@@ -398,7 +392,6 @@ background:#a6efed;
   background: transparent;
   transition: 1s;
   color: white;
-  outline: none;
 }
 
 input.profile-box {
@@ -429,7 +422,6 @@ color:white;
   cursor: pointer;
   transition: 1s;
   color: white;
-  outline: none;
 }
 
 .update-btn:hover{

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -97,6 +97,20 @@ const NavBar = () => {
 				) : (
 					<>
 						<Link
+							to="/categories"
+							className={styles.loggedInLink}
+							onClick={closeMenu}
+						>
+							Categories
+						</Link>
+						<Link
+							to="/cocktails"
+							className={styles.loggedInLink}
+							onClick={closeMenu}
+						>
+							Featured
+						</Link>
+						<Link
 							to="/login"
 							className={styles.loggedOutLink}
 							onClick={closeMenu}

--- a/src/components/SlideInPanel/SlideInPanel.jsx
+++ b/src/components/SlideInPanel/SlideInPanel.jsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom'
+import styles from './SlideInPanel.module.css'
+
+const SlideInPanel = ({ isOpen, onClose, unauthorizedAction }) => {
+	return (
+		<>
+			<div className={`${styles.panel} ${isOpen ? styles.panel__open : ''}`}>
+				<div className={styles.panel__content}>
+					<p>
+						Please{' '}
+						<Link to={`/login`}>
+							<span>log in</span>
+						</Link>{' '}
+						or{' '}
+						<Link to={`/signup`}>
+							<span>sign up</span>
+						</Link>
+						{` `}
+						to {unauthorizedAction},{' '}
+						{`${unauthorizedAction === 'like' ? 'follow' : 'like'} `} and post
+						cocktail recipes!
+					</p>
+				</div>
+			</div>
+			{isOpen ? <div className={styles.overlay} onClick={onClose} /> : null}
+		</>
+	)
+}
+
+export default SlideInPanel

--- a/src/components/SlideInPanel/SlideInPanel.module.css
+++ b/src/components/SlideInPanel/SlideInPanel.module.css
@@ -1,0 +1,112 @@
+.panel {
+    position: fixed;
+    top: var(--nav-height);
+    right: -22vw; /* Slide in from the right */
+    width: 22vw;
+    height: calc(100vh - var(--nav-height));
+    background-color: #fff;
+    box-shadow: -2px 0 5px rgba(0, 0, 0, 0.5);
+    transition: right 0.3s ease;
+    z-index: 3;
+}
+
+.panel p {
+    color: #706897;
+    font-size: 1.75rem;
+    font-weight: bolder;
+    background: white;
+    border-radius: 8px;
+    padding: 16px 40px;
+    margin: 2rem 0 0;
+}
+
+.panel__open.panel { /* ensure this has higher specificity */
+    right: 0; /* Slide in to view */
+}
+
+.panel__content {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    z-index: 4;
+}
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent */
+    z-index: 2; /* Behind the panel */
+    cursor: pointer;
+}
+
+@media (max-width: 450px) {
+    .panel {
+        right: -50vw;
+        width: 50vw;
+    }
+    .panel span, .panel p  {
+        font-size: 1.5rem;
+    }
+}
+
+@media ((min-width: 450px) and (max-width: 700px)) {
+    .panel {
+        right: -40vw;
+        width: 40vw;
+    }
+    .panel span, .panel p  {
+        font-size: 1.5rem;
+    }
+}
+
+@media ((min-width: 700px) and (max-width: 950px)) {
+    .panel {
+        right: -30vw;
+        width: 30vw;
+    }
+    .panel span, .panel p  {
+        font-size: 1.25rem;
+    }
+}
+
+@media ((min-width: 950px) and (max-width: 1200px)) {
+    .panel {
+        right: -30vw;
+        width: 30vw;
+    }
+    .panel span, .panel p  {
+        font-size: 1.75rem;
+    }
+}
+
+@media ((orientation: landscape) and (max-width: 950px)) {
+    .panel {
+        right: -26vw;
+        width: 26vw;
+    }
+    .panel span, .panel p  {
+        font-size: 1.25rem;
+    }
+}
+
+@media ((orientation: landscape) and (min-width: 950px) and (max-width: 1000px)) {
+    .panel span, .panel p  {
+        font-size: 1.5rem;
+    }
+}
+
+@media ((orientation: landscape) and (min-width: 1000px) and (max-width: 1200px)) {
+    .panel {
+        right: -24vw;
+        width: 24vw;
+    }
+    .panel span, .panel p  {
+        font-size: 1.5rem;
+    }
+}
+

--- a/src/features/auth/ProfileInfo/ProfileInfo.jsx
+++ b/src/features/auth/ProfileInfo/ProfileInfo.jsx
@@ -20,14 +20,6 @@ const ProfileInfo = ({ currentUser }) => {
 
 	const handleToggleModal = () => {
 		setIsModalOpen((prev) => !prev)
-		if (!isModalOpen) {
-			document.body.style.overflow = 'hidden' // Prevent background scrolling when modal is open
-			setTimeout(() => {
-				document.getElementById('modalContent').focus() // Explicitly set focus to the modal content
-			}, 100) // Allow some time for the modal to render
-		} else {
-			document.body.style.overflow = 'auto' // Restore background scrolling when modal is closed
-		}
 	}
 
 	return (
@@ -69,11 +61,7 @@ const ProfileInfo = ({ currentUser }) => {
 				)}
 			</div>
 
-			<div
-				id="modalContent"
-				tabIndex="-1"
-				className={`${styles.modal} ${isModalOpen ? styles.active : ''}`}
-			>
+			<div className={`${styles.modal} ${isModalOpen ? styles.active : ''}`}>
 				<UpdateProfile
 					currentUser={currentUser}
 					handleToggleModal={handleToggleModal}

--- a/src/features/categories/CategoryDetail/CategoryDetail.jsx
+++ b/src/features/categories/CategoryDetail/CategoryDetail.jsx
@@ -6,12 +6,17 @@ import CocktailCard from '../../cocktails/CocktailCard/CocktailCard'
 import { selectCategoryById } from '../categoriesSlice'
 import { useSelector } from 'react-redux'
 import React from 'react'
+import SlideInPanel from '../../../components/SlideInPanel/SlideInPanel'
+import useSlideInPanel from '../../../hooks/use-slide-in-panel'
 
 function CategoryDetail() {
 	const { id } = useParams()
 	const categoryDetail = useSelector((state) => selectCategoryById(state, id))
 
 	const { name, definition, cocktails } = categoryDetail || {}
+
+	const { isPanelOpen, openPanel, closePanel, unauthorizedAction } =
+		useSlideInPanel()
 
 	return categoryDetail ? (
 		<div className={styles.container}>
@@ -21,9 +26,18 @@ function CategoryDetail() {
 			</div>
 			<div className={styles.cocktailsGrid}>
 				{cocktails.map((cocktail) => (
-					<CocktailCard key={cocktail.id} id={cocktail.id} />
+					<CocktailCard
+						key={cocktail.id}
+						id={cocktail.id}
+						openPanel={openPanel}
+					/>
 				))}
 			</div>
+			<SlideInPanel
+				isOpen={isPanelOpen}
+				onClose={closePanel}
+				unauthorizedAction={unauthorizedAction}
+			/>
 			<img
 				className={appStyles.backgroundImage}
 				src={background}

--- a/src/features/cocktails/CocktailCard/CocktailCard.jsx
+++ b/src/features/cocktails/CocktailCard/CocktailCard.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { Error } from '../../../components/Error'
-import { handleLikeClick } from '../../../util/cocktail/AddCocktailLike'
+import { handleLike } from '../../../util/cocktail/AddCocktailLike'
 import {
 	addUsersLike,
 	deleteUsersLike,
@@ -17,7 +17,7 @@ import { selectCocktailById } from '../cocktailsSlice'
 import styles from './CocktailCard.module.css'
 import cocktailDefault from '../../../images/cocktail-default.jpeg'
 
-const CocktailCard = ({ id }) => {
+const CocktailCard = ({ id, openPanel }) => {
 	//reading the cocktail data from the store
 	const cocktail = useSelector((state) => selectCocktailById(state, id))
 	// current logged in user, to distinguish from the cocktail creator
@@ -41,8 +41,10 @@ const CocktailCard = ({ id }) => {
 
 	// memoized value to check if the current user has already liked the cocktail
 	const initialHasLiked = useMemo(
-		() => currentUser.likes.find((like) => like.liked_cocktail_id === id),
-		[currentUser.likes, id]
+		() =>
+			currentUser?.likes?.find((like) => like.liked_cocktail_id === id) ||
+			false,
+		[currentUser, id]
 	)
 
 	// state to set if the current user has already liked the cocktail
@@ -73,16 +75,17 @@ const CocktailCard = ({ id }) => {
 
 				<button
 					onClick={() =>
-						handleLikeClick({
-							hasLiked,
-							setHasLiked,
-							deleteLike,
+						handleLike({
 							addNewLike,
-							dispatch,
-							deleteUsersLike,
 							addUsersLike,
 							currentUser,
+							deleteLike,
+							deleteUsersLike,
+							dispatch,
+							hasLiked,
 							id,
+							setHasLiked,
+							openPanel,
 						})
 					}
 				>

--- a/src/features/cocktails/CocktailsContainer/CocktailsContainer.jsx
+++ b/src/features/cocktails/CocktailsContainer/CocktailsContainer.jsx
@@ -7,6 +7,8 @@ import { selectCurrentUser } from '../../auth/authSlice'
 import CocktailCard from '../CocktailCard/CocktailCard'
 import CocktailForm from '../CocktailForm/CocktailForm'
 import { selectAllCocktails } from '../cocktailsSlice'
+import SlideInPanel from '../../../components/SlideInPanel/SlideInPanel'
+import useSlideInPanel from '../../../hooks/use-slide-in-panel'
 
 let SearchCocktail = ({ searchText, onSearch, sort, onSort }) => {
 	return (
@@ -34,20 +36,23 @@ const CocktailsContainer = () => {
 	const user = useSelector(selectCurrentUser)
 	const isBartender = user?.bartender ?? false
 
+	//custome hook to manage state for the slide in panel
+	const { isPanelOpen, openPanel, closePanel, unauthorizedAction } =
+		useSlideInPanel()
+
+	//local states
 	const [toggleCocktailForm, setToggleCocktailForm] = useState(false)
 	const [searchText, setSearchText] = useState('')
 	const [sort, setSort] = useState('')
 
+	const handleToggleClick = () => {
+		setToggleCocktailForm((prev) => !prev)
+	}
 	const handleSearchText = (event) => {
 		setSearchText(event.target.value)
 	}
-
 	const handleSort = (event) => {
 		setSort(event.target.value)
-	}
-
-	const handleToggleClick = () => {
-		setToggleCocktailForm((prev) => !prev)
 	}
 
 	// 'i' flag makes the search case-insensitive
@@ -76,7 +81,7 @@ const CocktailsContainer = () => {
 	})
 
 	const cocktailCards = cocktailsToDisplay.map((cocktail) => (
-		<CocktailCard key={cocktail.id} id={cocktail.id} />
+		<CocktailCard key={cocktail.id} id={cocktail.id} openPanel={openPanel} />
 	))
 
 	let content
@@ -91,12 +96,12 @@ const CocktailsContainer = () => {
 
 	return (
 		<div className={styles.container}>
-			{!isBartender ? null : (
+			{user && isBartender && (
 				<button className={styles.addCocktail} onClick={handleToggleClick}>
 					{toggleCocktailForm ? 'Hide Cocktail Form' : 'Add Cocktail'}
 				</button>
 			)}
-			{!toggleCocktailForm ? null : <CocktailForm />}
+			{user && toggleCocktailForm && <CocktailForm />}
 			<SearchCocktail
 				searchText={searchText}
 				onSearch={handleSearchText}
@@ -104,6 +109,12 @@ const CocktailsContainer = () => {
 				onSort={handleSort}
 			/>
 			{content}
+			<SlideInPanel
+				isOpen={isPanelOpen}
+				onClose={closePanel}
+				unauthorizedAction={unauthorizedAction}
+			/>
+
 			<img
 				className={appStyles.backgroundImage}
 				src={cocktailsCon}

--- a/src/features/cocktails/CocktailsContainer/CocktailsContainer.module.css
+++ b/src/features/cocktails/CocktailsContainer/CocktailsContainer.module.css
@@ -30,7 +30,6 @@
     font-size: 16px;
     font-weight: 700;
     transition: 1s;
-    outline: none;
     cursor: pointer;
     margin-top: 2rem;
     padding: 8px;
@@ -42,7 +41,7 @@
     align-items: center;
     height: 100vh;
     margin-top: var(--nav-height);
-    padding: 0 3rem;
+    padding: 1rem 3rem 0;
     gap: 2rem;
 }
 
@@ -63,12 +62,13 @@
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     grid-gap: 3rem;
     text-align: center;
+    justify-items: center;
 }
 
 @media (max-width: 300px) {
     .container {
         gap: 1rem;
-        padding: 0 1.5rem
+        padding: 1rem 1.5rem 0
     }
     .cocktailsGrid {
         grid-template-columns: repeat(1, 1fr);
@@ -89,7 +89,7 @@
 @media (min-width: 340px) and (max-width: 430px) {
     .container {
         gap: 1rem;
-        padding: 0 2rem;
+        padding: 1rem 2rem 0;
     }
     .cocktailsGrid {
         padding: 0 0 1rem;
@@ -110,7 +110,7 @@
 @media (min-width: 430px) and (max-width: 600px) {
     .container {
         gap: 1rem;
-        padding: 0 1rem;
+        padding: 1rem 1rem 0;
     }
     .cocktailsGrid {
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -134,7 +134,7 @@
 @media (min-width: 600px) and (max-width: 840px) {
     .container {
         gap: 1.5rem;
-        padding: 0 1rem;
+        padding: 1rem 1rem 0;
     }
     .cocktailsGrid {
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -159,7 +159,7 @@
 @media (min-width: 840px) and (max-width: 1180px) {
     .container {
         gap: 2rem;
-        padding: 0 1rem;
+        padding: 2rem 2rem 0;
     }
     .cocktailsGrid {
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -170,7 +170,7 @@
         margin-top: 1rem;;
     }
     .toolbar {
-        width: 97%
+        width: 100%
     }
     .search {
         width: 20%;
@@ -182,12 +182,13 @@
 
 @media (min-width: 1200px) and (max-width:1750px) {
     .container {
-        padding: 0 2rem;
-        gap: 1rem;
+        padding: 2rem 2rem 0;
+        gap: 1.5rem;
     }
     .cocktailsGrid {
         grid-template-columns: repeat(5, 1fr);
         grid-gap: 1rem;
+        padding: 0
     }
 }
 @media (min-width: 1750px) {
@@ -200,7 +201,7 @@
 @media (orientation: landscape) and (min-width: 600px) and (max-width: 800px) {
     .container {
         gap: 1rem;
-        padding: 0 1.5rem;
+        padding: 1rem 1.5rem 0;
     }
     .cocktailsGrid {
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -211,18 +212,21 @@
 @media (orientation: landscape) and (min-width: 800px) and (max-width: 950px) {
     .container {
         gap: 0.5rem;
-        padding: 0 1rem;
+        padding: 2rem 2rem 0;
     }
     .cocktailsGrid {
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         padding: 0;
+    }
+    .toolbar {
+        width: 100%
     }
 }
 
 @media (orientation: landscape) and (min-width: 950px) and (max-width: 1100px) {
     .container {
         gap: 0.5rem;
-        padding: 0 1rem;
+        padding: 1rem 1rem 0;
     }
 
     .cocktailsGrid {
@@ -231,12 +235,19 @@
     }
 }
 
-@media (orientation: landscape) and (min-width: 1100px) and (max-width: 1400px) {
+@media (orientation: landscape) and (min-width: 1100px) and (max-width: 1200px) {
     .container {
         gap: 1rem;
-        padding: 0 1rem;
+        padding: 1rem 1rem 0;
+    }
+}
+
+@media (orientation: landscape) and (min-width: 1200px) and (max-width: 1400px) {
+    .container {
+        gap: 1rem;
+        padding: 1rem 1rem 0;
     }
     .cocktailsGrid {
-        padding: 0 1rem;
+        padding: 0 1rem
     }
 }

--- a/src/hooks/use-slide-in-panel.js
+++ b/src/hooks/use-slide-in-panel.js
@@ -1,0 +1,20 @@
+import { useState } from 'react'
+
+const useSlideInPanel = () => {
+	const [isPanelOpen, setIsPanelOpen] = useState(false)
+	const [unauthorizedAction, setUnauthorizedAction] = useState('')
+	const openPanel = (unauthorizedAction) => {
+		setIsPanelOpen(true)
+		if (unauthorizedAction) {
+			setUnauthorizedAction(unauthorizedAction)
+		}
+	}
+	const closePanel = () => {
+		setIsPanelOpen(false)
+		setUnauthorizedAction('')
+	}
+
+	return { isPanelOpen, openPanel, closePanel, unauthorizedAction }
+}
+
+export default useSlideInPanel

--- a/src/util/cocktail/AddCocktailLike.js
+++ b/src/util/cocktail/AddCocktailLike.js
@@ -1,13 +1,13 @@
-export const handleLikeClick = async ({
-	hasLiked,
-	setHasLiked,
-	deleteLike,
+const handleLikeClick = async ({
 	addNewLike,
-	dispatch,
-	deleteUsersLike,
 	addUsersLike,
 	currentUser,
+	deleteLike,
+	deleteUsersLike,
+	dispatch,
+	hasLiked,
 	id,
+	setHasLiked,
 }) => {
 	if (hasLiked) {
 		try {
@@ -29,4 +29,34 @@ export const handleLikeClick = async ({
 			console.error('Failed to like:', requestError)
 		}
 	}
+}
+
+export const handleLike = async ({
+	addNewLike,
+	addUsersLike,
+	currentUser,
+	deleteLike,
+	deleteUsersLike,
+	dispatch,
+	hasLiked,
+	id,
+	setHasLiked,
+	openPanel,
+}) => {
+	if (!currentUser) {
+		openPanel('like')
+		return
+	}
+
+	await handleLikeClick({
+		addNewLike,
+		addUsersLike,
+		currentUser,
+		deleteLike,
+		deleteUsersLike,
+		dispatch,
+		hasLiked,
+		id,
+		setHasLiked,
+	})
 }

--- a/src/util/user/AddUserFollow.js
+++ b/src/util/user/AddUserFollow.js
@@ -1,0 +1,62 @@
+const handleFollowClick = async ({
+	addNewFollow,
+	addUserToFollow,
+	bartender,
+	currentUser,
+	deleteFollow,
+	deleteUserFollowed,
+	dispatch,
+	hasFollowed,
+	setHasFollowed,
+}) => {
+	if (hasFollowed) {
+		try {
+			await deleteFollow(hasFollowed.id).unwrap() // delete the follow
+			setHasFollowed(undefined) // reset the state
+			dispatch(deleteUserFollowed(hasFollowed.id)) // remove the follow from the store
+		} catch (requestError) {
+			console.error('Failed to unfollow:', requestError)
+		}
+	} else {
+		try {
+			const newFollow = await addNewFollow({
+				follower_id: currentUser.id,
+				followee_id: bartender.id,
+			})
+			setHasFollowed(newFollow) // set the new follow
+			dispatch(addUserToFollow(newFollow.data)) // add the follow to the store
+		} catch (requestError) {
+			console.error('Failed to follow:', requestError)
+		}
+	}
+}
+
+export const handleFollow = async ({
+	addNewFollow,
+	addUserToFollow,
+	bartender,
+	currentUser,
+	deleteFollow,
+	deleteUserFollowed,
+	dispatch,
+	hasFollowed,
+	openPanel,
+	setHasFollowed,
+}) => {
+	if (!currentUser) {
+		openPanel('follow')
+		return
+	}
+
+	await handleFollowClick({
+		addNewFollow,
+		addUserToFollow,
+		bartender,
+		currentUser,
+		deleteFollow,
+		deleteUserFollowed,
+		dispatch,
+		hasFollowed,
+		setHasFollowed,
+	})
+}


### PR DESCRIPTION
- remove authentication for most pages of the app except for Profile page.
- bug was solved by turning off React Dev Tools extension: removed "outline:none" in App's css file, as blue line, removed modal's accessibility and focus for background scrolling
- added SlideInPanel feature: including component, cs module and a custom hook, to prompt user to log in or sign up
- abstract out `handleFollow` to its own util file to refract the CocktailDetail component